### PR TITLE
Fix: Improve MCP STDERR handling and simplify project UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,10 +143,10 @@ const McpConfigTranslator = ({ onTranslate }) => {
   );
 };
 
-// Enhanced Project Management Component
-const ProjectManagementTab = ({ currentProject, setCurrentProject, onProjectChange, api, showToast }) => {
-  const [projects, setProjects] = useState([]);
-  const [managedProjects, setManagedProjects] = useState(() => {
+// Enhanced Project Management Component - REMOVED as per user request to simplify project management
+// const ProjectManagementTab = ({ currentProject, setCurrentProject, onProjectChange, api, showToast }) => {
+//   const [projects, setProjects] = useState([]);
+//   const [managedProjects, setManagedProjects] = useState(() => {
     const saved = localStorage.getItem('gemini-cli-managed-projects');
     return saved ? JSON.parse(saved) : [];
   });
@@ -1512,16 +1512,16 @@ function App() {
           />
         );
 
-      case 'projects':
-        return (
-          <ProjectManagementTab
-            currentProject={currentProject}
-            setCurrentProject={setCurrentProject}
-            onProjectChange={handleProjectChange}
-            api={api}
-            showToast={showToast}
-          />
-        );
+      // case 'projects': // Removed as per user request
+      //   return (
+      //     <ProjectManagementTab
+      //       currentProject={currentProject}
+      //       setCurrentProject={setCurrentProject}
+      //       onProjectChange={handleProjectChange}
+      //       api={api}
+      //       showToast={showToast}
+      //     />
+      //   );
 
       case 'tools':
         return (

--- a/src/ModernChatInterface.jsx
+++ b/src/ModernChatInterface.jsx
@@ -780,7 +780,7 @@ export const ModernChatInterface = ({
             {showFileSelector && (
               <FileSelector
                 show={showFileSelector}
-                currentPath={settings.baseFolderPath || '/'}
+                currentPath={currentProject || settings.baseFolderPath || '/'}
                 searchQuery={fileSearch}
                 onSelect={selectFile}
                 onClose={() => setShowFileSelector(false)}

--- a/src/ModernComponents.jsx
+++ b/src/ModernComponents.jsx
@@ -115,7 +115,7 @@ export const ModernButton = ({
 export const ModernSidebar = ({ activeTab, setActiveTab, isCollapsed, setIsCollapsed }) => {
   const navItems = [
     { id: 'chat', icon: MessageCircle, label: 'Chat Interface', badge: null },
-    { id: 'projects', icon: Folder, label: 'Repositories', badge: null },
+    // { id: 'projects', icon: Folder, label: 'Repositories', badge: null }, // Removed as per user request
     { id: 'tools', icon: Zap, label: 'Tools & MCP', badge: null },
     { id: 'terminal', icon: Terminal, label: 'Terminal', badge: null },
     { id: 'authentication', icon: User, label: 'Authentication', badge: null },


### PR DESCRIPTION
This commit addresses several issues and implements UI simplifications based on user feedback:

1.  **MCP STDERR Handling (server/index.js):**
    - Filters noisy output (including "MCP STDERR", deprecation warnings, debug messages, and Vite connection messages) from PTY sessions before sending to the WebSocket client. This aims to prevent the server from jamming due to problematic stderr.

2.  **Project Management UI Simplification (src/App.jsx, src/ModernComponents.jsx):**
    - Removed the dedicated "Projects" tab from the sidebar.
    - Removed the `ProjectManagementTab` component and its rendering logic.
    - Project selection now relies on the top bar project selector and the "Working Folders" feature within the chat interface.

3.  **`@` Command File Selector (src/ModernChatInterface.jsx):**
    - The file selector triggered by the `@` command now correctly prioritizes the `currentProject` path as its starting point.
    - It falls back to `settings.baseFolderPath` or root (`/`) if no project is active. This fixes issues where the selector might not have started in the correct project directory.

The investigation into `.env` and `settings.json` behavior concluded that the existing system is internally consistent, though its interaction with `localStorage` and project-specific files might lead to unexpected changes if not fully understood. No code changes were made to this part. The `!` command execution path also remains unchanged as its server-side handling for `!command` syntax appears correct.